### PR TITLE
Refactored read.tucson2 and update QA results

### DIFF
--- a/QA_Stuff/compare-old-new-read-tucson.csv
+++ b/QA_Stuff/compare-old-new-read-tucson.csv
@@ -1,0 +1,117 @@
+Chronology,Core,Year,New,Old,Explanation
+indi010,kancd11a,1960,1.4,0.14,Text is shifted one character to the right so old version misread
+cana209,EGR108,,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+ct001,PB1S,1698 - 1709,,,"Only one line of header, old version missed first two rows"
+nj002,HF2W,,,,"Duplicated HF 2W, one with texts shifted left one space, old version read as HF 2W 1 and years shifted by 1000 years"
+nj001,HF2W,,,,"Duplicated HF 2W, one with texts shifted left one space, old version read as HF 2W 1 and years shifted by 1000 years"
+va024,"12A, 25B",,,,Strange EOL caused old version to misread some data points
+mt109,GRM713,1716 - 1719,,missing,Old version missed the first line
+ut521,SK101A,1739,0.17,missing,Old version missed the first line
+ut522,SK201A,,,missing,Old version missed the first line
+neth031,ABGD544,1948 - 1949,2.22,"0.22, 22.2","Text shifted right by one space, old version misread"
+ca614,first core,,,,Old version missed the first line
+va021,first core,,,,Old version missed the first line
+ca615,first core,,,,Old version missed the first line
+ca616,first core,,,,Old version missed the first line
+mexi029,first core,,,,Old version missed the first line
+ca618,first core,,,,Old version missed the first line
+ca619,first core,,,,Old version missed the first line
+ca620,first core,,,,Old version missed the first line
+ca621,first core,,,,Old version missed the first line
+ca623,first core,,,,Old version missed the first line
+ca625,first core,,,,Old version missed the first line
+ca626,first core,,,,Old version missed the first line
+mexi037,first core,,,,Old version missed the first line
+mexi001,,,,,Old version missed the first line
+arge42b,,,,,Some lines staggered all over the place
+wi002,first core,,,,Old version missed the first line
+ak015,EL46SE,1850 - 1851,,,"Text shifted right by one space, old version misread"
+germ036,SIN06B,1925 - 1926,,,"Text shifted right by one space, old version misread"
+ne005,sna112,1776 - 1779,,,"Text shifted right by two spaces, old version misread"
+co006,stu081,1622,0.06,0.006,"Text shifted right by one space, old version misread"
+mexi042,first core,,,,Old version missed the first line
+nm580,first core,,,,Old version missed the first line
+ca648,first core,,,,Old version missed the first line
+ca649,first core,,,,Old version missed the first line
+mexi044,first core,,,,Old version missed the first line
+mexi045,first core,,,,Old version missed the first line
+ca653,first core,,,,Old version missed the first line
+ca651,first core,,,,Old version missed the first line
+ca652,first core,,,,Old version missed the first line
+ca654,first core,,,,Old version missed the first line
+ca655,first core,,,,Old version missed the first line
+ca656,first core,,,,Old version missed the first line
+tx051,first core,,,,Old version missed the first line
+tx050,first core,,,,Old version missed the first line
+ca657,first core,,,,Old version missed the first line
+ok033,first core,,,,Old version missed the first line
+ca660,first core,,,,Old version missed the first line
+ca645,first core,,,,Old version missed the first line
+ca661,first core,,,,Old version missed the first line
+ca659,first core,,,,Old version missed the first line
+ca662,first core,,,,Old version missed the first line
+ca663,first core,,,,Old version missed the first line
+ca646,first core,,,,Old version missed the first line
+ca664,first core,,,,Old version missed the first line
+mexi041,first core,,,,Old version missed the first line
+ca650,first core,,,,Old version missed the first line
+ca658,first core,,,,Old version missed the first line
+ca665,first core,,,,Old version missed the first line
+ca647,first core,,,,Old version missed the first line
+mexi046,first core,,,,Old version missed the first line
+mexi038,first core,,,,Old version missed the first line
+russ218,"rv2s, rv8e",,,,"Text shifted right by one space, old version misread"
+mexi047,first core,,,,Old version missed the first line
+tx052,first core,,,,Old version missed the first line
+tx053,first core,,,,Old version missed the first line
+tx054,first core,,,,Old version missed the first line
+chin061,DLS104B,"1278, 1279","0.11, 0.09","0.01, 0.19","Text shifted right by one space, old version misread"
+indi025,nar07b,"1963, 1964","12.19, 7.64","1.21, 97.64","Text shifted right by one space, old version misread"
+kyrg014,kok3a,,,,"This core has two different precision flags, old version only read the 2nd flag, new version detects and throws an error"
+mi024,first core,,,,Old version missed the first line
+mi021,PLK18A,1990 - 1999,,missing,Strange EOL caused old version to misread some data points
+ca688,first core,,,,Old version missed the first line
+ca689,first core,,,,Old version missed the first line
+nc025,first core,,,,Old version missed the first line
+co651,first core,,,,Old version missed the first line
+co652,first core,,,,Old version missed the first line
+ausl043,SPR01C,"1693, 1694","1, 0.52","0.1, 0.052","Text shifted right by one space, old version misread"
+ausl045,mrr08nw,1840 - 1849,,,Strange EOL caused old version to misread some data points
+ausl049,DX081,"1800, 1801","37.28, 25","3.72, 825","Text shifted right by one space, old version misread"
+ak159,"F082bn04, F281_016",,,,"Text shifted right by one space, old version misread"
+ak160,,,,,"Text shifted right by one space, old version misread"
+ausl053,,,,,"Text shifted right by one space, old version misread"
+mt158,first core,,,,Old version missed the first line
+ma028,first core,,,,Old version missed the first line
+ma029,first core,,,,Old version missed the first line
+russ301,,,,,Encoding error
+bra009,,,,,"Texts stagged all over the place, but not bunched up, so new version read correctly while old version doesn't"
+bra010,,,,,"Texts stagged all over the place, but not bunched up, so new version read correctly while old version doesn't"
+tha021,MV2-1C,"1938, 1939",,,"Letter C becomes c in core ID, new version treated as two cores, old version changed to upper case"
+co691,wpx181,-267 and  -266,,,"Text shifted right by one space, old version misread"
+rus319,B42s7a,1603 - 1609,,,"Text shifted right by one space, old version misread"
+can694,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can695,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can696,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can697,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can698,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can699,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can700,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can701,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can702,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can703,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can704,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can705,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can706,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can707,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can708,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can709,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can710,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can711,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can712,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can713,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can714,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can715,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+can716,every core,every year,,,"Short core ID, old version read ""1"" into core ID and years shifted by 1000"
+mar035,,,,,"Text shifted right by one space, old version misread"
+mar047,,,,,"Text shifted right by one space, old version misread"

--- a/QA_Stuff/compare_read_tucson2.R
+++ b/QA_Stuff/compare_read_tucson2.R
@@ -1,0 +1,69 @@
+# # HN: compare old and new read.tucson.
+# # Making sure that the new one gets it right whenever the old one gets it right
+# # and improve on the other cases
+# 
+# library(doFuture)
+# source("QA_Stuff/read_tucson2.R")
+# 
+# load("RdataFiles/cleaned_itrdb.Rdata")
+# head(itrdb_meta)
+# # get studies with RWL files
+# studies2get <- itrdb_meta$RWL_Count > 0
+# summary(studies2get)
+# studies_gt_one <- itrdb_meta$RWL_Count > 1
+# summary(studies_gt_one)
+# 
+# rwls_meta <- itrdb_meta[studies2get, ]
+# rwls_meta <- droplevels(rwls_meta)
+# head(rwls_meta)
+# 
+# rwls2get <- itrdb_rwl[studies2get]
+# 
+# fnameUsed <- sapply(rwls2get, \(s) {
+#    fname <- if (length(s) > 1) {
+#       getShorty <- which.min(nchar(s))
+#       s[getShorty]
+#    } else s
+#    paste0("./data_files/", fname)
+# })
+# 
+# plan(multisession)
+# checks <- foreach(s = fnameUsed, .final = unlist, .inorder = FALSE) %dofuture% {
+#    foo1 <- try(rwl_to_dt(read.tucson2(s, verbose = FALSE)),
+#                silent = TRUE)
+#    foo2 <- try(rwl_to_dt(read.tucson(s)),
+#                silent = TRUE)
+#    if (!inherits(foo2, "try-error") && !inherits(foo1, "try-error")) {
+#       all.equal(foo1[order(core, year)], foo2[order(core, year)])
+#    } else FALSE
+# }
+# 
+# mismatch <- which(checks != '1' & checks != 'TRUE')
+out <- data.table(
+   crn = names(fnameUsed[mismatch]),
+   fname = fnameUsed[mismatch],
+   diff = checks[mismatch])
+fwrite(out, 'QA_stuff/mismatches.csv')
+
+fnameMismatch <- fread('QA_Stuff/mismatches.csv', header = TRUE)[, fname]
+file <- fnameMismatch[129]
+file
+
+foo1 <- read.tucson2(file, verbose = TRUE) |> rwl_to_dt()
+foo2 <- read.tucson(file) |> rwl_to_dt()
+# foo2 <- read.tucson(file, long = TRUE) |> rwl_to_dt()
+setkey(foo1, core, year)
+setkey(foo2, core, year)
+
+foo1
+foo2
+
+merged <- merge(foo1, foo2, by = c('core', 'year'))
+merged[abs(rw.x - rw.y) > 1e-4]
+
+foo2[!foo1]
+foo1[!foo2]
+
+all.equal(foo1, foo2)
+ file
+

--- a/QA_Stuff/long-negative-years-rwls.csv
+++ b/QA_Stuff/long-negative-years-rwls.csv
@@ -1,0 +1,10 @@
+brit039,Year < -999; corrected if set long = TRUE
+brit037,Year < -999; corrected if set long = TRUE
+brit036,Year < -999; corrected if set long = TRUE
+ausl024,Year < -999; corrected if set long = TRUE
+chin067,Year < -999; corrected if set long = TRUE
+chin069,Year < -999; corrected if set long = TRUE
+swed334,Year < -999; corrected if set long = TRUE
+turk044,Year < -999; corrected if set long = TRUE
+turk045,Year < -999; corrected if set long = TRUE
+turk046,Year < -999; corrected if set long = TRUE

--- a/QA_Stuff/mismatches.csv
+++ b/QA_Stuff/mismatches.csv
@@ -1,0 +1,130 @@
+crn,fname,diff
+INDI010,./data_files/treering/measurements/asia/indi010.rwl,Column 'rw': Mean relative difference: 0.0009758515
+BRIT039,./data_files/treering/measurements/europe/brit039.rwl,FALSE
+BRIT037,./data_files/treering/measurements/europe/brit037.rwl,FALSE
+BRIT036,./data_files/treering/measurements/europe/brit036.rwl,FALSE
+CANA209,./data_files/treering/measurements/northamerica/canada/cana209.rwl,Column 'core': 103 string mismatches
+CT001,./data_files/treering/measurements/northamerica/usa/ct001.rwl,Different number of rows
+NJ002,./data_files/treering/measurements/northamerica/usa/nj002.rwl,Column 'core': 238 string mismatches
+NJ001,./data_files/treering/measurements/northamerica/usa/nj001.rwl,Column 'core': 238 string mismatches
+AUSL024,./data_files/treering/measurements/australia/ausl024.rwl,FALSE
+VA024,./data_files/treering/measurements/northamerica/usa/va024.rwl,Column 'rw': Mean relative difference: 0.02569651
+MT109,./data_files/treering/measurements/northamerica/usa/mt109.rwl,Different number of rows
+UT521,./data_files/treering/measurements/northamerica/usa/ut521.rwl,Different number of rows
+UT522,./data_files/treering/measurements/northamerica/usa/ut522.rwl,Different number of rows
+TURK029,./data_files/treering/measurements/europe/turk029.rwl,Different number of rows
+NETH031,./data_files/treering/measurements/europe/neth031.rwl,Column 'rw': Mean relative difference: 0.0007581553
+OR005,./data_files/treering/measurements/northamerica/usa/or005.rwl,Different number of rows
+CA614,./data_files/treering/measurements/northamerica/usa/ca614.rwl,Different number of rows
+VA021,./data_files/treering/measurements/northamerica/usa/va021.rwl,Different number of rows
+CA615,./data_files/treering/measurements/northamerica/usa/ca615.rwl,Different number of rows
+CA616,./data_files/treering/measurements/northamerica/usa/ca616.rwl,Different number of rows
+MEXI029,./data_files/treering/measurements/northamerica/mexico/mexi029.rwl,Different number of rows
+CA618,./data_files/treering/measurements/northamerica/usa/ca618.rwl,Different number of rows
+CA619,./data_files/treering/measurements/northamerica/usa/ca619.rwl,Different number of rows
+CA620,./data_files/treering/measurements/northamerica/usa/ca620.rwl,Different number of rows
+CA621,./data_files/treering/measurements/northamerica/usa/ca621.rwl,Different number of rows
+CA623,./data_files/treering/measurements/northamerica/usa/ca623.rwl,Different number of rows
+CA625,./data_files/treering/measurements/northamerica/usa/ca625.rwl,Different number of rows
+CA626,./data_files/treering/measurements/northamerica/usa/ca626.rwl,Different number of rows
+MEXI037,./data_files/treering/measurements/northamerica/mexico/mexi037.rwl,Different number of rows
+AZ143,./data_files/treering/measurements/northamerica/usa/az143.rwl,Column 'rw': Mean relative difference: 0.002802951
+MEXI001,./data_files/treering/measurements/northamerica/mexico/mexi001.rwl,Different number of rows
+ARGE065,./data_files/treering/measurements/southamerica/arge065.rwl,Column 'rw': Mean relative difference: 0.005252791
+ARGE041,./data_files/treering/measurements/southamerica/arge041.rwl,Different number of rows
+WI002,./data_files/treering/measurements/northamerica/usa/wi002.rwl,Different number of rows
+AK015,./data_files/treering/measurements/northamerica/usa/ak015.rwl,Column 'rw': Mean relative difference: 0.0007641251
+GERM036,./data_files/treering/measurements/europe/germ036.rwl,Column 'rw': Mean relative difference: 0.007403511
+NE005,./data_files/treering/measurements/northamerica/usa/ne005.rwl,Column 'rw': Mean relative difference: 0.0003746402
+CO628,./data_files/treering/measurements/northamerica/usa/co628.rwl,Column 'rw': Mean relative difference: 7.830433e-05
+MEXI042,./data_files/treering/measurements/northamerica/mexico/mexi042.rwl,Different number of rows
+NM580,./data_files/treering/measurements/northamerica/usa/nm580.rwl,Different number of rows
+CA648,./data_files/treering/measurements/northamerica/usa/ca648.rwl,Different number of rows
+CA649,./data_files/treering/measurements/northamerica/usa/ca649.rwl,Different number of rows
+MEXI044,./data_files/treering/measurements/northamerica/mexico/mexi044.rwl,Different number of rows
+MEXI045,./data_files/treering/measurements/northamerica/mexico/mexi045.rwl,Different number of rows
+CA653,./data_files/treering/measurements/northamerica/usa/ca653.rwl,Different number of rows
+CA651,./data_files/treering/measurements/northamerica/usa/ca651.rwl,Different number of rows
+CA652,./data_files/treering/measurements/northamerica/usa/ca652.rwl,Different number of rows
+CA654,./data_files/treering/measurements/northamerica/usa/ca654.rwl,Different number of rows
+CA655,./data_files/treering/measurements/northamerica/usa/ca655.rwl,Different number of rows
+CA656,./data_files/treering/measurements/northamerica/usa/ca656.rwl,Different number of rows
+TX051,./data_files/treering/measurements/northamerica/usa/tx051.rwl,Different number of rows
+TX050,./data_files/treering/measurements/northamerica/usa/tx050.rwl,Different number of rows
+CA657,./data_files/treering/measurements/northamerica/usa/ca657.rwl,Different number of rows
+OK033,./data_files/treering/measurements/northamerica/usa/ok033.rwl,Different number of rows
+CA660,./data_files/treering/measurements/northamerica/usa/ca660.rwl,Different number of rows
+CA645,./data_files/treering/measurements/northamerica/usa/ca645.rwl,Different number of rows
+CA661,./data_files/treering/measurements/northamerica/usa/ca661.rwl,Different number of rows
+CA659,./data_files/treering/measurements/northamerica/usa/ca659.rwl,Different number of rows
+CA662,./data_files/treering/measurements/northamerica/usa/ca662.rwl,Different number of rows
+CA663,./data_files/treering/measurements/northamerica/usa/ca663.rwl,Different number of rows
+CA646,./data_files/treering/measurements/northamerica/usa/ca646.rwl,Different number of rows
+CA664,./data_files/treering/measurements/northamerica/usa/ca664.rwl,Different number of rows
+MEXI041,./data_files/treering/measurements/northamerica/mexico/mexi041.rwl,Different number of rows
+CA650,./data_files/treering/measurements/northamerica/usa/ca650.rwl,Different number of rows
+CA658,./data_files/treering/measurements/northamerica/usa/ca658.rwl,Different number of rows
+CA665,./data_files/treering/measurements/northamerica/usa/ca665.rwl,Different number of rows
+CA647,./data_files/treering/measurements/northamerica/usa/ca647.rwl,Different number of rows
+MEXI046,./data_files/treering/measurements/northamerica/mexico/mexi046.rwl,Different number of rows
+MEXI038,./data_files/treering/measurements/northamerica/mexico/mexi038.rwl,Different number of rows
+RUSS218,./data_files/treering/measurements/asia/russ218.rwl,Column 'rw': Mean relative difference: 0.01453346
+MEXI047,./data_files/treering/measurements/northamerica/mexico/mexi047.rwl,Different number of rows
+TX052,./data_files/treering/measurements/northamerica/usa/tx052.rwl,Different number of rows
+TX053,./data_files/treering/measurements/northamerica/usa/tx053.rwl,Different number of rows
+TX054,./data_files/treering/measurements/northamerica/usa/tx054.rwl,Different number of rows
+CHIN061,./data_files/treering/measurements/asia/chin061.rwl,Column 'rw': Mean relative difference: 0.0003739646
+INDI025,./data_files/treering/measurements/asia/indi025.rwl,Column 'rw': Mean relative difference: 0.172039
+KYRG014,./data_files/treering/measurements/asia/kyrg014.rwl,FALSE
+MI021,./data_files/treering/measurements/northamerica/usa/mi021.rwl,Different number of rows
+CHIN067,./data_files/treering/measurements/asia/chin067.rwl,FALSE
+CHIN069,./data_files/treering/measurements/asia/chin069.rwl,FALSE
+CA688,./data_files/treering/measurements/northamerica/usa/ca688.rwl,Different number of rows
+CA689,./data_files/treering/measurements/northamerica/usa/ca689.rwl,Different number of rows
+SWED334,./data_files/treering/measurements/europe/swed334.rwl,FALSE
+NC025,./data_files/treering/measurements/northamerica/usa/nc025.rwl,Different number of rows
+CO651,./data_files/treering/measurements/northamerica/usa/co651.rwl,Different number of rows
+CO652,./data_files/treering/measurements/northamerica/usa/co652.rwl,Different number of rows
+AUSL043,./data_files/treering/measurements/australia/ausl043.rwl,Column 'rw': Mean relative difference: 0.0003804226
+TURK044,./data_files/treering/measurements/europe/turk044.rwl,FALSE
+TURK045,./data_files/treering/measurements/europe/turk045.rwl,FALSE
+TURK046,./data_files/treering/measurements/europe/turk046.rwl,FALSE
+AUSL045,./data_files/treering/measurements/australia/ausl045.rwl,Column 'rw': Mean relative difference: 0.002014755
+AUSL049,./data_files/treering/measurements/australia/ausl049.rwl,Column 'rw': Mean relative difference: 0.02746529
+AK159,./data_files/treering/measurements/northamerica/usa/ak159.rwl,Column 'rw': Mean relative difference: 0.002597217
+AK160,./data_files/treering/measurements/northamerica/usa/ak160.rwl,Column 'rw': Mean relative difference: 0.01171247
+AUSL053,./data_files/treering/measurements/australia/ausl053.rwl,FALSE
+MT158,./data_files/treering/measurements/northamerica/usa/mt158.rwl,Different number of rows
+MA028,./data_files/treering/measurements/northamerica/usa/ma028.rwl,Different number of rows
+MA029,./data_files/treering/measurements/northamerica/usa/ma029.rwl,Different number of rows
+RUSS301,./data_files/treering/measurements/asia/russ301.rwl,FALSE
+BRA009,./data_files/treering/measurements/southamerica/bra009.rwl,Different number of rows
+BRA010,./data_files/treering/measurements/southamerica/bra010.rwl,Different number of rows
+THA021,./data_files/treering/measurements/asia/tha021.rwl,Column 'core': 4 string mismatches
+CO691,./data_files/treering/measurements/northamerica/usa/co691.rwl,Column 'rw': Mean relative difference: 0.002758094
+RUS319,./data_files/treering/measurements/asia/rus319.rwl,Column 'rw': Mean relative difference: 0.06545608
+CAN694,./data_files/treering/measurements/northamerica/canada/can694.rwl,Column 'core': 6314 string mismatches
+CAN695,./data_files/treering/measurements/northamerica/canada/can695.rwl,Column 'core': 7645 string mismatches
+CAN696,./data_files/treering/measurements/northamerica/canada/can696.rwl,Column 'core': 7783 string mismatches
+CAN697,./data_files/treering/measurements/northamerica/canada/can697.rwl,Column 'core': 14964 string mismatches
+CAN698,./data_files/treering/measurements/northamerica/canada/can698.rwl,Column 'core': 6974 string mismatches
+CAN699,./data_files/treering/measurements/northamerica/canada/can699.rwl,Column 'core': 6062 string mismatches
+CAN700,./data_files/treering/measurements/northamerica/canada/can700.rwl,Column 'core': 3536 string mismatches
+CAN701,./data_files/treering/measurements/northamerica/canada/can701.rwl,Column 'core': 7926 string mismatches
+CAN702,./data_files/treering/measurements/northamerica/canada/can702.rwl,Column 'core': 6560 string mismatches
+CAN703,./data_files/treering/measurements/northamerica/canada/can703.rwl,Column 'core': 18636 string mismatches
+CAN704,./data_files/treering/measurements/northamerica/canada/can704.rwl,Column 'core': 14838 string mismatches
+CAN705,./data_files/treering/measurements/northamerica/canada/can705.rwl,Column 'core': 4162 string mismatches
+CAN706,./data_files/treering/measurements/northamerica/canada/can706.rwl,Column 'core': 5536 string mismatches
+CAN707,./data_files/treering/measurements/northamerica/canada/can707.rwl,Column 'core': 4855 string mismatches
+CAN708,./data_files/treering/measurements/northamerica/canada/can708.rwl,Column 'core': 13119 string mismatches
+CAN709,./data_files/treering/measurements/northamerica/canada/can709.rwl,Column 'core': 7438 string mismatches
+CAN710,./data_files/treering/measurements/northamerica/canada/can710.rwl,Column 'core': 5055 string mismatches
+CAN711,./data_files/treering/measurements/northamerica/canada/can711.rwl,Column 'core': 8688 string mismatches
+CAN712,./data_files/treering/measurements/northamerica/canada/can712.rwl,Column 'core': 12292 string mismatches
+CAN713,./data_files/treering/measurements/northamerica/canada/can713.rwl,Column 'core': 9016 string mismatches
+CAN714,./data_files/treering/measurements/northamerica/canada/can714.rwl,Column 'core': 7413 string mismatches
+CAN715,./data_files/treering/measurements/northamerica/canada/can715.rwl,Column 'core': 6157 string mismatches
+CAN716,./data_files/treering/measurements/northamerica/canada/can716.rwl,Column 'core': 4163 string mismatches
+MAR035,./data_files/treering/measurements/africa/mar035.rwl,Column 'rw': Mean relative difference: 0.00113492
+MAR047,./data_files/treering/measurements/africa/mar047.rwl,Column 'rw': Mean relative difference: 0.008579524

--- a/QA_Stuff/read_tucson2.R
+++ b/QA_Stuff/read_tucson2.R
@@ -1,7 +1,11 @@
 library(data.table)
 library(dplR)
 
-read.tucson2 <- function(file, fix.duplicates = FALSE, fix.dup.char = 'X', verbose = TRUE) {
+
+read.tucson2 <- function(file, header = NULL, 
+                         comment.char = '#',
+                         fix.duplicates = TRUE, fix.dup.char = 'X', 
+                         verbose = TRUE) {
 
   # Fix those cores with a huge chunk of missing rings in the middle
   # e.g. BT006 core CAMPS12B
@@ -18,107 +22,257 @@ read.tucson2 <- function(file, fix.duplicates = FALSE, fix.dup.char = 'X', verbo
     x
   }
 
+  count_letters <- function(char.vector) sapply(gregexpr("[[:alpha:]]", substr(char.vector, 9, 72)), length)
+  
   # First, read the whole file into a data.table, one row per row.
   # This data.table has a single column with name V1 by default.
-  raw <- fread(file, sep = '\n', header = FALSE)[V1 != '']
+  # strip.white = FALSE because sometimes core IDs have spaces in front.
+  raw <- fread(file, header = FALSE, sep = '\n', 
+               blank.lines.skip = TRUE, strip.white = FALSE)
+  
+  # Clean up ----------------------------------------------------------------------
+  # Sometimes the file has mixed EOL chars, esp. between the headers and the body, and fread can fail. 
+  # This will result in one or four rows only in the read result.
+  # Special case: pak042 has a wrong EOL in PSL0, likely edited in a Mac to a file from Windows
+  # This caused two lines to merge
+  # Replace \r with \n and reread the text (not the file)
 
-  # If there is a header, the second line will have more than 72 characters
-  if (nchar(raw[2, V1]) > 72) raw <- raw[-(1:3)]
+  # if (nrow(raw) == 1) {
+  #   if (regexpr('\r', raw) > 0) {
+  #     raw <- gsub('\r', '\n', raw)
+  #     raw <- fread(text = raw, sep = '\n', header = FALSE)
+  #   }
+  # } else if (nrow(raw) == 4) {
+  #   if (regexpr('\r', raw$V1[4]) > 0) {
+  #     raw2 <- gsub('\r', '\n', raw$V1[4])
+  #     raw2 <- fread(text = raw2, sep = '\n', header = FALSE)
+  #     raw  <- rbind(raw[1:3], raw2)
+  #   }
+  # }
+  
+  rIdx <- which(regexpr('\r', raw$V1) > 0)
+  if (length(rIdx) > 0) {
+    reRead <- rbindlist(lapply(rIdx, \(k) {
+      raw2 <- gsub('\r', '\n', raw$V1[k])
+      fread(text = raw2, sep = '\n', header = FALSE)
+    }))
+    raw <- rbind(raw[-rIdx], reRead)  
+  }
+  
+  raw <- raw[regexpr(comment.char, V1) < 0] # Remove lines with comments    
+  raw <- raw[substr(V1, 1, 1) != '\032']    # Strange EOF 
+  
+  # Find lines that are too long. Sometimes a file has notes at the end of the line
+  raw[nchar(V1) > 72, V1 := substr(V1, 1, 72)] 
 
+  # Trim trailing white 
+  # Leave leading white spaces because we can safely handles a lot of cases
+  # with 8-char IDs that has spaces in front.
+  raw[, V1 := trimws(V1, 'right')]          
+  raw <- raw[nchar(V1) > 12]                # Remove rows that are too short
+  
+  # Remove headers
+  # In principal a data line should not have any non-numeric character after the 13th position
+  # so we can use grepl("[[:alpha:]]", substr(line, 9, 72)) to detect header lines
+  # however, there are some files with several letters e.g. az615
+  # Some files use NaN to mark missing rings
+  # So we say a data line should not have "too many" letters
+  # How many is too many? Let's keep it at 3 (as it is now with the problematic files).
+  raw <- raw[count_letters(V1) <= 3]                     
+
+  # Check for header
   # Remove duplicated rows due to copy-paste
   dups <- duplicated(raw)
   if (any(dups) > 0) {
-    warning(paste('Identical rows detected and removed in', file),
+    warning(paste('Identical rows detected and removed in', file, '\n'),
             paste0(capture.output(raw[dups][order(V1)]), collapse = '\n'))
     raw <- raw[!dups]
   }
-
-  # Parsing --------------------------------------
-
-  raw[, firstSpace := regexpr(' ', V1)]   # Determine the location of the first space character in each line
-  cols <- paste0('Y', 0:9)                # Year 0 to year 9 for each row
-
-  raw[, c('core', 'startYear', cols) := {
-    # Get the numbers after the first space
-    tailString <- substr(V1, firstSpace, nchar(V1))
-    tailNums <- strsplit(tailString, ' ')[[1]] |> as.integer()
-    tailNums <- tailNums[!is.na(tailNums)]
-    N <- length(tailNums)
-
-    # If the first space is after 8, core IDs may be bunched up with the year e.g., ABCD101A1750 100 200 300
-    # Scenarios:
-    #   If there are 10 numbers and no -9999 -> year bunching
-    #   If there are 10 numbers or less and -9999, needs to check the previous row
-    #   However, since the operation is vectorized, we can't check the previous row immediately
-    #   So, assume there is year bunching (more common), and check back with the second pass (TODO)
-    if ((firstSpace <= 9) || (N == 11)) {
-      # coreID is before firstSpace, startYear is first 4 chars after space, firstMeasure is 5 chars after that
-      core <- substr(V1, 1, firstSpace - 1)
-      startYear <- tailNums[1]
-      if ((tailNums[N] == 999) && (N < 11)) tailNums[N] <- -999
-      measures <- split(tailNums[2:11], cols)
-    } else {
-      # When year bunching occurs, if there is the negative sign, year < -999
-      if (regexpr('-', V1)[[1]] > 0) {
-        core <- substr(V1, 1, firstSpace - 6)
-        startYear <- as.integer(substr(V1, firstSpace - 5, firstSpace - 1))
+  
+  # Parsing 
+  # A row has two parts: head and tail
+  # Head is ID + year (which can be bunched). 
+  #    This should be 12 chars ending with a digit
+  #    Cana209 is an exception
+  # Tail should be a bunch of numbers
+  #    Max 3 characters allowed
+  #    Those with characters will be converted to NA
+  
+  # Split head ----------------------------------------------------------
+  
+  startDigits <- c(as.character(1:9), '-')
+  raw[, c('core', 'startYear') := {
+    
+    headString <- substr(V1, 1, 12)
+    if (substr(headString, 12, 12) != ' ') {
+      if (substr(headString, 8, 8) == '-') {
+        startYear <- substr(headString, 8, 12)
+        core      <- substr(headString, 1, 7)
       } else {
-        core <- substr(V1, 1, firstSpace - 5)
-        startYear <- as.integer(substr(V1, firstSpace - 4, firstSpace - 1))
+        startYear <- substr(headString, 9, 12)
+        core      <- substr(headString, 1, 8)
       }
-      if (tailNums[N] == 999) tailNums[N] <- -999 # Convert 999 flag to -999
-      tailNums <- c(tailNums, rep(NA, 10 - N)) # pad NA to avoid split warning when length(cols) > length(split)
-      measures <- split(tailNums, cols)
+    } else { 
+      # cana209, nj001, nj002: year shifted left, not bunch
+      # japa018: year shifted left, bunched
+      if (substr(headString, 7, 7) == '-') {
+        startYear <- substr(headString, 7, 11)
+        core      <- substr(headString, 1, 6)
+      } else {
+        if (substr(headString, 8, 8) %in% startDigits) {
+          startYear <- substr(headString, 8, 11)
+          core      <- substr(headString, 1, 7)
+        } else {
+          startYear <- substr(headString, 9, 11)
+          core      <- substr(headString, 1, 8)
+        }
+      }
     }
-    c(list(core, startYear), measures)
-  }, by = seq_len(nrow(raw))
-  ]
-  raw[, c('V1', 'firstSpace') := NULL]
+    list(core = core, startYear = startYear)
+  }, by = seq_len(nrow(raw))]
+  
+  raw[, ':='(startYear = as.integer(startYear),
+             core = trimws(core))]  
+  raw <- raw[!is.na(startYear)][order(core, startYear)]
+  
+  # Looking for the precision flag at the last row of each core ----
+  raw[, flag := {
+    V1 <- .SD[.N, V1]
+    tailStrings <- strsplit(substr(V1, 13, nchar(V1)), ' ')[[1]]
+    tailStrings <- tailStrings[nzchar(tailStrings)]
+    
+    # Handling dash, -9999 can be bunched (mexi077)
+    M <- length(tailStrings)
+    dashLoc <- gregexpr("-", tailStrings)
+    hasDash <- which(dashLoc > 1)
+    if (length(hasDash) == 1) {
+      tmp <- tailStrings[hasDash]
+      tailStrings[hasDash] <- substr(tmp, 1, dashLoc[[hasDash]] - 1)
+      if (hasDash == M) {
+        tailStrings <- c(tailStrings[1:hasDash],
+                         substr(tmp, dashLoc[[hasDash]], nchar(tmp)))
+      } else {
+        tailStrings <- c(tailStrings[1:hasDash],
+                         substr(tmp, dashLoc[[hasDash]], nchar(tmp)),
+                         tailStrings[(hasDash + 1) : M])
+      }
+    } 
+    tailNums <- suppressWarnings(as.numeric(tailStrings))
+    if (tailNums[length(tailNums)] == -9999) -9999 else 999
+  }, by = core]
+  raw <- raw[!is.na(flag)]
+  # Split tail ----
+    
+  # Uncomment to debug problematic lines
+  V1 <- raw$V1[546]
 
+  cols <- paste0('Y', 0:9)                # Year 0 to year 9 for each row
+  
+  raw[, c(cols) := {
+    
+    tailStrings <- substr(V1, 13, nchar(V1))
+    
+    # Check if empty spaces are used for missing rings.
+    # In this case we have 6 empty spaces in a row
+    # Read fix-width 
+    if (grepl('      ', tailStrings)) {
+      pos <- seq(from = 13, by = 6, length.out = 10)
+      tailStrings <- sapply(pos, \(x) substr(V1, x, x + 5))
+    } else {
+    # Otherwise, split the numbers by spaces
+      tailStrings <- strsplit(tailStrings, ' ')[[1]]
+      tailStrings <- tailStrings[nzchar(tailStrings)]
+    }
+    
+    tailNums <- suppressWarnings(as.integer(tailStrings))
+    
+    # String to numbers ----
+    
+    # Handling dash ----
+    # Sometimes measurements look like this 1234-50623, e.g. ak165
+    # Need to detect "-" and split it.
+    # This is rare, I don't expect more than once per row
+    M <- length(tailStrings)
+    dashLoc <- gregexpr("-", tailStrings)
+    hasDash <- which(dashLoc > 1)
+    if (length(hasDash) == 1) {
+      tmp <- tailStrings[hasDash]
+      tailStrings[hasDash] <- substr(tmp, 1, dashLoc[[hasDash]] - 1)
+      if (hasDash == M) {
+        tailStrings <- c(tailStrings[1:hasDash],
+                         substr(tmp, dashLoc[[hasDash]], nchar(tmp)))
+      } else {
+        tailStrings <- c(tailStrings[1:hasDash],
+                         substr(tmp, dashLoc[[hasDash]], nchar(tmp)),
+                         tailStrings[(hasDash + 1) : M])
+      }
+    } 
+    #   ----
+    
+    tailNums <- suppressWarnings(as.numeric(tailStrings))
+    N <- length(tailNums)
+    
+    # Special cases -----------------------------------------------
+    if (N == 0) {
+      message('In ', file, ', line ', V1, ' has no number, skipped.')
+      tailNums <- rep(NA, 10)
+    } else {
+      # Check for non-numeric in measurements  
+      hasNA <- is.na(tailNums)
+      if (any(hasNA)) {
+        message('In ', file, ' core ', core, ' decade starting ', startYear, ', ', sum(hasNA), ' measurement(s) have non-numeric characters, converted to zeros.')
+      }
+      
+      # Check for very large numbers
+      # Numbers > 999999 will be bunched up. In this case, read by fixed width
+      if (length(which(tailNums > 999999)) > 0) {
+        pos <- seq(from = 13, by = 6, length.out = 10)
+        tailStrings <- sapply(pos, \(x) substr(V1, x, x + 5))
+        tailNums <- as.numeric(tailStrings)
+        N <- length(tailNums)
+      }
+      
+      tailNums[tailNums < 0 & tailNums != -9999] <- NA # some files use negative numbers for missing rings
+      tailNums[tailNums == flag] <- NA      
+      # Convert to measurements  
+      if (N < 10) tailNums <- c(tailNums, rep(NA, 10 - N)) # pad NA to have length 10
+    }
+    split(tailNums, cols)
+  }, by = seq_len(nrow(raw))]
+  
+  raw[, V1 := NULL]
+  
   # Convert to long format
   parsed <- melt(
     raw,
-    id.vars = c('core', 'startYear'),
+    id.vars = c('core', 'startYear', 'flag'),
     variable.name = 'yearOrder',
     variable.factor = FALSE,
     value.name = 'rw')[order(core, startYear)][!is.na(rw)]
-
-  # Now apply precision
-  # Split cores may have more than one precision flag -> only keep one. If the flags are different, throw error
-  precisionDT <- parsed[rw == -9999 | rw == -999]
-  precisionCount <- precisionDT[, .N, by = core]
-
-  if (any(precisionCount$N > 1)) {
-    twoFlags <- precisionDT[core %in% precisionCount[N > 1, core]]
-    diffFlag <- twoFlags[, .(diff = diff(rw)), by = core]
-    if (any(diffFlag$diff > 0))
-      stop(paste0('In ', file, ', different precision flags on the same core', diffFlag[diff > 0, core]))
+  
+  # At this point, if there is still a -9999 value in rw
+  # That means the flag is different from -9999 -> two flags
+  twoFlags <- parsed[rw < 0]
+  if (nrow(twoFlags) > 0) {
+    stop('In ', file, ', core(s) ', paste(twoFlags$core, collapse = ' '), ' have different precision flags.')
   }
-
-  precisionDT <- precisionDT[, tail(.SD, 1), by = core]
-  precisionDT[, precision := fifelse(rw == -9999, 0.001, 0.01)]
-
-  parsed <- merge(parsed, precisionDT[, .(core, precision)], by = 'core', all.x = TRUE)
+  
+  parsed[, precision := fifelse(flag == 999, 0.01, 0.001)]
   parsed[, rw := rw * precision]
-
-  # Now we can convert those negative flags to NA
-  # This also remove the hanging -9999
-  parsed[rw < 0, rw := NA]
-  parsed <- parsed[!is.na(rw)]
-
+  
   # Finally we calculate the year from the startYear and the yearOrder
   parsed[, year := startYear + as.integer(substr(yearOrder, 2, 2))]
-  # Clean up
-  parsed[, c('startYear', 'yearOrder', 'precision') := NULL]
+  
+  parsed[, c('startYear', 'yearOrder', 'flag') := NULL]
 
   # Fix duplicated core and year but with different measurements
   dups <- duplicated(parsed, by = c('core', 'year'))
 
   if (any(dups)) {
     warning(paste0('Duplicated core names in ', file,
-                   '. Core IDs for the second measurements are affixed with',
+                   '. Core IDs for the second measurements are affixed with ',
                    fix.dup.char, '\n'),
-            merge(parsed[!dups], parsed[dups],
+            merge(parsed[!dups, .(core, year, rw)], parsed[dups, .(core, year, rw)],
                   by = c('core', 'year'),
                   suffixes = c('.1', '.2')) |>
               capture.output() |>
@@ -127,12 +281,37 @@ read.tucson2 <- function(file, fix.duplicates = FALSE, fix.dup.char = 'X', verbo
   }
 
   # Now cast to wide to fill middle NA
-  out <- dcast(parsed, year ~ core, value.var = 'rw')
-  out[, (2:ncol(out)) := lapply(.SD, fill_middle_NAs), .SDcols = 2:ncol(out)]
+  out <- dcast(parsed[, .(year, core, rw)], year ~ core, value.var = 'rw')
   out <- as.data.frame(out)
   rownames(out) <- out$year
   out$year <- NULL
-  if (verbose) print(out)
+  
+  # In rare cases the longest core has a missing segment before the next longest core begins 
+  # and this won't be filled by dcast
+  # So fill manually here
+  repeat {
+    years <- as.integer(rownames(out))
+    yearDiff <- diff(years)
+    gapIdx <- which(yearDiff != 1)
+    if (length(gapIdx) == 0) break
+    M <- ncol(out)
+    N <- nrow(out)
+    filler <- matrix(NA, yearDiff[gapIdx[1]] - 1, M)
+    colnames(filler) <- colnames(out)
+    rownames(filler) <- (years[gapIdx[1]] + 1) : (years[gapIdx[1]+1]-1)
+    out <- rbind(
+      out[1:gapIdx[1], ],
+      filler,
+      out[(gapIdx[1]+1):N, ])  
+  }
+  
+  out <- as.data.frame(apply(out, 2, fill_middle_NAs))
+  
+  if (verbose) {
+    summary <- parsed[, .(start = year[1], end = year[.N], precision = precision[1]), by = core]
+    cat('There are ', nrow(summary), ' series.\n')
+    print(summary)
+  }
   # AGB making the output class rwl as well as df for dplR compatibility.
   class(out) <- c("rwl","data.frame")
   out

--- a/QA_Stuff/run-checks-read-tucson2-errors-on-20240503.R
+++ b/QA_Stuff/run-checks-read-tucson2-errors-on-20240503.R
@@ -1,0 +1,93 @@
+library(dplR)
+library(doFuture)
+source("QA_Stuff/read_tucson2.R")
+studies2check <- read.csv("QA_Stuff/studies_that_failed.csv")
+# grab a problem child
+
+
+checks <- rep(FALSE, nrow(studies2check))
+for (ii in 1:nrow(studies2check)) {
+  print(ii)
+  if (!ii %in% c(324, 502)) {
+    foo1 <- read.tucson2(studies2check$rwlfilename[ii], verbose = FALSE) |> rwl_to_dt()
+    foo2 <- invisible(read.tucson(studies2check$rwlfilename[ii])) |> rwl_to_dt()
+    checks[ii] <- all.equal(foo1[order(core, year)], foo2[order(core, year)])
+  }
+}
+
+mismatch <- which(checks != '1' & checks != 'TRUE')
+mismatch
+checks[mismatch]
+
+# New version misses
+# 4  :  brit008 : space in ID (fixed)
+# 6  :  turk033 : 73-char lines (fixed)
+#    :  fran10  : headers in the middle of file with comment lines (fixed)
+# 9  :  cana7rw : 4 lines of header, 4th lines has # (fixed)
+# 21 :  cana015 : multiple 999 as end (fixed)
+# 22 :  wa059   : strange character at end of file (fixed)
+# 80 :  neth025 : End-of-line problem (fixed)
+# 324:  kyrg014 : mixed precision - throw errors **********
+# 464:  swit384 : space in ID (fixed)
+# 465:  swit385 : space in ID (fixed)
+# 466:  mong043b: both space and '-' in ID (fixed)
+# 480:  az615   : core AZP0310A, year 1992; core AZP0310B, year 1957: characters in measurements (fixed)
+# 502:  russ301 : has Russian character  ************
+# 507:  fl010   : space in name, long core name (fixed)
+# 508:  bol019  : weird number year 1866 core sot875 (fixed)
+# 516:  deu317  : dmm0606m and dmm0625m, year 1799 actual 999 measurement at end of line (fixed)
+# 545:  fl014   : multiple header lines (fixed)
+# 561:  ita065  : multiple comment lines not starting with #, produced by Coorecorder (fixed)
+# 577:  dza004  : headers more than 3 lines (fixed); 
+# 580:  dza017  : 6 digit ring size (fixed)
+#       cana136 : space in file name, followed by number, bunched with year (fixed)
+#       mexi077 : -9999 shifted left and bunched (fixed)
+#       or005   : gaps for missing value, missed it.
+#       mex117  : numbers very large all bunched up
+# 538-544:   che417-423: -999 used as missing ring (fixed)
+
+
+# OG misses
+#  14:  ct001   : only one line of header, OG missed first 2 data lines
+#  18:  va024   : OG missed some numbers in 12A and 25B due to non-standard EOL
+#  77:  neth031 : core ABGD544 off by 1 character, OG read as 0.22 instead of 2.22 
+# 170:  swit177x: mixed -999 and 0 for zero rings; cores 638002, 638003, 638010: read -999 as zero at the end before the 999 mark 
+# 377:  ausl043 : core SPR01C off by one character in years 1693, 1694; OG read as 0.1 instead of 1, and 0.052 instead of 0.52
+
+
+file <- studies2check$rwlfilename[577]
+file
+
+# file <- 'data_files/treering/measurements/northamerica/canada/cana209.rwl'
+# file <- 'data_files/treering/measurements/northamerica/usa/ak165.rwl'
+# file <- 'data_files/treering/measurements/europe/tur090.rwl'
+# file <- 'data_files/treering/measurements/southamerica/chil013.rwl'
+# file <- 'data_files/treering/measurements/northamerica/mexico/mexi077.rwl'
+# file <- 'data_files/treering/measurements/northamerica/canada/cana015.rwl'
+# file <- 'data_files/treering/measurements/europe/czec1.rwl'
+# file <- 'data_files/treering/measurements/asia/kyrg014.rwl'
+file <- 'data_files/treering/measurements/asia/or005.rwl'
+
+foo1 <- read.tucson2(file, verbose = FALSE)
+
+foo1 <- read.tucson2(file, verbose = FALSE) |> rwl_to_dt()
+foo2 <- read.tucson(file) |> rwl_to_dt()
+setkey(foo1, core, year)
+setkey(foo2, core, year)
+
+foo1
+foo2
+
+merged <- merge(foo1, foo2, by = c('core', 'year'))
+merged[abs(rw.x - rw.y) > 1e-4]
+
+foo1[!foo2]
+foo2[!foo1]
+
+all.equal(foo1, foo2)
+
+microbenchmark::microbenchmark(
+  dplR::read.tucson(file),
+  read.tucson2(file, verbose = FALSE),
+  times = 1
+)

--- a/QA_Stuff/studies_that_failed_20240509.csv
+++ b/QA_Stuff/studies_that_failed_20240509.csv
@@ -1,0 +1,3 @@
+"","XML_FileName","rwlfilename","errorThrown"
+"KYRG014","noaa-tree-15249.xml","./data_files/treering/measurements/asia/kyrg014.rwl","In ./data_files/treering/measurements/asia/kyrg014.rwl, core(s) kok3a have different precision flags."
+"RUSS301","noaa-tree-35579.xml","./data_files/treering/measurements/asia/russ301.rwl","invalid multibyte string at '<c1><e4>89'"


### PR DESCRIPTION
I rewrote `read.tucson2()` and updated QA results.

The new version is aimed at reproducing everything that the OG got right and improved on the other cases.

Now v2 has successfully read 6137 out of 6139 rwls. The two cases that caused errors are **kyrg014**, which has two different precision flags, and **russ301**, which has non-unicode characters. The latter was fixed on ITRDB.

v2 and OG now has different results on 116 out of 6139 rwls.

Some of the common data file issues that caused the OG to misread:

* Different Mac / Windows EOL characters causing the OG to miss the first line of the data: **62** cases
* Text is shifted right by one or two characters causing OG to read one order of magnitude off: **18** cases
* Short IDs causing years to shift by 1000 years in OG: **24 cases**
